### PR TITLE
feat(tools): add reproducible Kallsyms recovery workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 ghostlock
 ace6t_exploit
 bash.exe.stackdump
+
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `pselect6` syscall copies `fd_set` data onto the kernel stack. When combined
 |--------|-----|--------|--------|
 | OnePlus Ace 6T (PLR110) | SM8845 | `6.12.38-...-ab14275539` | **Working** |
 | OnePlus Ace 6T (PLR110) | SM8845 | `6.12.38-...-ab14552068` | **Working** |
-| OnePlus 15 (CPH2749) | SM8850 | `6.12.23-...-ab14541642` | **Working** |
+| OnePlus 15 (CPH2745 / CPH2747 / CPH2749) | SM8850 | `6.12.23-...-ab14541642` | **Working** |
 | Xiaomi 17 (pudding) | SM8850 | `6.12.23-...-abogki463945075` | **Working** |
 | Xiaomi 17 (pudding) | SM8850 | `6.12.69-...-abogki514973465` | **Working** (August 2026 update) |
 | OnePlus 13 (IN2060) | SM8750 | `6.6.89-...-abogki446052083` | **Working** (`PSELECT_SHIFT=-2`) |
@@ -93,7 +93,7 @@ Root shell         →  ksud late-load (KernelSU LKM)
                    →  dynamic manager registration
 ```
 
-### Bootstrap Mode (phone standalone)
+### Bootstrap Mode (phone standalone, optional)
 
 ```
 App (seccomp)  →  Write 1 (no perf needed)
@@ -102,10 +102,10 @@ App (seccomp)  →  Write 1 (no perf needed)
                →  root → KSU → network fix
 ```
 
-### Auto-Boot (via ReSukiSU integration)
+### Optional auto-boot integration
 
 ```
-BOOT_COMPLETED → BootCompletedReceiver
+BOOT_COMPLETED → companion-app BootCompletedReceiver
   ├─ su available → skip (soft reboot / already rooted)
   └─ no root → GhostlockService → setsid exploit --bootstrap
 ```
@@ -194,14 +194,35 @@ echo 'p:rw rt_mutex_wait_proxy_lock waiter=%x2' >> /sys/kernel/tracing/kprobe_ev
 
 ## Build
 
+Build from the repository root. The recommended command is:
+
+```bash
+cd /path/to/ghostlock-oneplus
+make NDK_ROOT=/path/to/android-ndk
+```
+
+This creates the executable at:
+
+```text
+/path/to/ghostlock-oneplus/ghostlock
+```
+
+In other words, the output is `./ghostlock` in the directory where `make` is
+run; it is not placed inside the NDK or under `src/`. On Windows, run this
+build from WSL or another Linux environment and use the resulting ARM64
+executable.
+
+To invoke the compiler directly instead of `make`, run this command from the
+same repository root. The `-o ./ghostlock` option writes to that same location:
+
 ```bash
 NDK=/path/to/android-ndk
-$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android35-clang \
-  -O2 -Wall -Isrc/core -Isrc/devices -DTARGET_CONFIG_H="target.h" \
+"$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android35-clang" \
+  -O2 -Wall -Isrc/core -Isrc/devices -DTARGET_CONFIG_H=\"target.h\" \
   src/core/main.c src/core/util.c src/core/slide.c \
   src/core/fops.c src/core/pipe_physrw.c src/core/root.c \
   src/core/miniadb.c src/core/umh_root.c \
-  -o ghostlock -fPIE -pie -pthread
+  -o ./ghostlock -fPIE -pie -pthread
 ```
 
 ## Prerequisites
@@ -217,32 +238,90 @@ GhostLock only provides root. KernelSU installation depends on **ksud** — a bi
 
 > Without ksud, the exploit achieves root (uid=0) but KSU won't be installed and `su` won't persist.
 
-## Setup (one-time)
+## Setup and direct ADB run
+
+The normal run uses the connected device's ADB shell. Before starting, make
+sure USB debugging is enabled, the device is unlocked enough to approve the
+computer's ADB key, and `adb devices` shows the device with state `device`:
 
 ```bash
-# Enable ADB TCP (use any port)
-adb tcpip 5555
-
-# Push exploit binary and ADB key
-adb push ghostlock /data/local/tmp/a/e && adb shell chmod 755 /data/local/tmp/a/e
-adb push ~/.android/adbkey /data/local/tmp/a/adbkey
-
-# If using a non-default ADB port (e.g. 23946):
-adb shell "echo 23946 > /data/local/tmp/a/adb_port"
+adb devices
 ```
 
-After first successful jailbreak, `persist.adb.tcp.port` is set via `resetprop` — subsequent boots are fully automatic.
+If the state is `unauthorized`, unlock the phone, approve the RSA prompt, and
+run `adb devices` again.
+
+Build `ghostlock` first, then run these commands from the repository root:
+
+```bash
+# Create the directory on the phone, then copy the host binary there.
+adb shell mkdir -p /data/local/tmp/a
+adb push ./ghostlock /data/local/tmp/a/e
+adb shell chmod 755 /data/local/tmp/a/e
+```
+
+Execute the copied binary on the phone with:
+
+```bash
+adb shell /data/local/tmp/a/e
+```
+
+`adb shell` is important: `/data/local/tmp/a/e` is a path on the phone, so
+entering that path by itself in the computer's terminal will not run it. If
+you rebuild the binary, repeat the `adb push` and `chmod` commands before
+running it again. In PowerShell, `./ghostlock` can also be written as
+`.\ghostlock`.
+
+## Optional bootstrap mode
+
+`--bootstrap` is for launching from an app or another restricted phone-side
+process. The normal direct ADB command above is the preferred way to run the
+exploit from a computer. Bootstrap mode needs a local ADB-over-TCP endpoint and
+the ADB private key used to authenticate to it:
+
+```bash
+# Enable ADB TCP on the connected phone (the default port is 5555).
+adb tcpip 5555
+
+# The binary should already be installed at /data/local/tmp/a/e.
+adb push ~/.android/adbkey /data/local/tmp/a/adbkey
+
+# Optional: use another port. The two commands must use the same port.
+# adb tcpip 23946
+# adb shell "echo 23946 > /data/local/tmp/a/adb_port"
+
+# Launch the phone-side bootstrap flow.
+adb shell /data/local/tmp/a/e --bootstrap
+```
+
+On Windows PowerShell, the private key is usually
+`$env:USERPROFILE\.android\adbkey`. Treat this file as sensitive.
+
+A successful run changes the current kernel and can load KernelSU through
+`ksud`. ReSukiSU jailbreak-mode state is tied to the current boot; after a
+reboot, run the exploit again unless a separate boot-time integration is
+configured. An ADB TCP setting only controls how ADB connects and does not by
+itself preserve root.
 
 ## Usage
 
 ```bash
-/data/local/tmp/a/e                        # Full exploit (adb shell)
-/data/local/tmp/a/e --bootstrap            # Phone standalone (app context)
-/data/local/tmp/a/e --write1               # SELinux disable only
-PSELECT_SHIFT=-2 /data/local/tmp/a/e       # Override stack layout shift
+# Run from a computer through ADB.
+adb shell /data/local/tmp/a/e
+
+# Optional phone-side mode for a companion app.
+adb shell /data/local/tmp/a/e --bootstrap
+
+# Diagnostic/partial operation.
+adb shell /data/local/tmp/a/e --write1
+
+# OnePlus 13 / another profile that needs a shift override.
+adb shell "PSELECT_SHIFT=-2 /data/local/tmp/a/e"
 ```
 
-> **Important**: Run within 30 seconds of boot for best KernelSnitch timing reliability.
+Start after Android has finished booting and ADB is ready. There is no fixed
+30-second post-boot deadline; if a timing-sensitive attempt reports a timeout,
+run the command again.
 
 ## Adding New Devices / Kernel Versions
 
@@ -255,8 +334,14 @@ Only `boot.img` is needed — no root, no device access required.
 python -c "import struct; d=open('boot.img','rb').read(); open('kernel','wb').write(d[4096:4096+struct.unpack_from('<I',d,8)[0]])"
 
 # 2. Global symbols (kallsyms)
-python tools/extract_target.py    # 28 offsets, auto-validated
+python tools/extract_target.py --kallsyms kallsyms.txt    # 28 offsets, auto-validated
+```
 
+For stage 2, use the [kallsyms tools guide](tools/kallsyms/GUIDE.md) to recover
+`kallsyms.txt` from `boot.img`. It covers kernel extraction, `vmlinux`
+reconstruction, and symbol export, starting with the standard AOSP path.
+
+```bash
 # 3. Struct fields (BTF)
 python tools/extract_btf.py kernel  # 57 offsets, auto-validated
 

--- a/tools/extract_btf.py
+++ b/tools/extract_btf.py
@@ -113,6 +113,13 @@ FIELDS_NEEDED = {
         "filter_count": "SECCOMP_FILTER_COUNT_OFF",
         "filter": "SECCOMP_FILTER_OFF",
     },
+    "selinux_state": {
+        "enforcing": "SELINUX_STATE_ENFORCING_OFF",
+        "initialized": "SELINUX_STATE_INITIALIZED_OFF",
+        "policycap": "SELINUX_STATE_POLICYCAP_OFF",
+        "android_netlink_route": "SELINUX_STATE_NETLINK_ROUTE_OFF",
+        "android_netlink_getneigh": "SELINUX_STATE_NETLINK_GETNEIGH_OFF",
+    },
     "pipe_inode_info": {
         "head": "PIPE_HEAD_OFF",
         "tail": "PIPE_TAIL_OFF",
@@ -143,6 +150,21 @@ FIELDS_NEEDED = {
     },
 }
 
+def print_offset_header():
+    print(f"  {'Define':<40} {'Extracted':>8} {'Expected':>8} {'Match':>6}")
+    print(f"  {'-' * 40} {'-' * 8} {'-' * 8} {'-' * 6}")
+
+def print_offset_row(define_name, extracted, expected):
+    extracted_text = f"0x{extracted:X}" if extracted is not None else "MISS"
+    expected_text = f"0x{expected:X}" if expected is not None else "N/A"
+    if extracted is not None and expected is not None:
+        match = "OK" if extracted == expected else "DIFF!"
+    elif extracted is not None:
+        match = "NEW"
+    else:
+        match = "MISS"
+    print(f"  {define_name:<40} {extracted_text:>8} {expected_text:>8} {match:>6}")
+
 def main():
     kernel_path = sys.argv[1] if len(sys.argv) > 1 else "C:/Android/kernel_raw"
     data = open(kernel_path, 'rb').read()
@@ -165,30 +187,25 @@ def main():
     if os.path.exists(target_h):
         with open(target_h, encoding='utf-8') as f:
             for line in f:
-                m = re.match(r'#define\s+(\w+_OFF)\s+(0x[0-9a-fA-F]+)', line)
+                m = re.match(r'#define\s+(\w+_OFF)\s+(0x[0-9a-fA-F]+|[0-9]+)', line)
                 if m:
-                    current[m.group(1)] = int(m.group(2), 16)
+                    current[m.group(1)] = int(m.group(2), 0)
 
     results = {}
+    struct_reports = []
     for struct_name, fields in FIELDS_NEEDED.items():
         hits = find_struct_in_btf(type_data, str_data, struct_name)
         if not hits:
-            print(f"\n{struct_name}: NOT FOUND")
+            struct_reports.append((struct_name, None, None, fields))
             continue
         # Pick the largest match (most members = most complete definition)
         size, members = max(hits, key=lambda x: len(x[1]))
         member_dict = {name: off for name, off in members}
-        print(f"\n{struct_name} (size={size}, {len(members)} members):")
         for field_name, define_name in sorted(fields.items(), key=lambda x: x[1]):
             off = member_dict.get(field_name)
-            cur = current.get(define_name)
-            b = f"0x{off:X}" if off is not None else "MISS"
-            c = f"0x{cur:X}" if cur is not None else "N/A"
-            match = "OK" if (off is not None and cur is not None and off == cur) else \
-                    "DIFF!" if (off is not None and cur is not None and off != cur) else "MISS"
-            print(f"  {define_name:<40} {b:>8} {c:>8} {match:>6}")
             if off is not None:
                 results[define_name] = off
+        struct_reports.append((struct_name, size, len(members), fields))
 
     # Handle fields in nested/anonymous structs
     # mm_struct.owner: inside anonymous inner struct, find by brute-force
@@ -207,7 +224,6 @@ def main():
                     byte_off = bit_off // 8
                     if 0x100 <= byte_off <= 0x800:
                         results["MM_OWNER_OFF"] = byte_off
-                        print(f"\n  MM_OWNER_OFF (brute-force): 0x{byte_off:X}")
                         break
             if "MM_OWNER_OFF" in results and results["MM_OWNER_OFF"] is not None:
                 break
@@ -215,17 +231,25 @@ def main():
 
     # rt_mutex_waiter.prio/deadline: after rb_node (24 bytes) in tree field
     # tree is at offset 0, rb_node is 24 bytes, then prio(4) + pad(4) + deadline(8)
-    if "WAITER_PRIO_OFF" not in results or results["WAITER_PRIO_OFF"] is None:
-        tree_off = results.get("WAITER_TREE_ENTRY_OFF", 0)
+    if ("WAITER_PRIO_OFF" not in results or results["WAITER_PRIO_OFF"] is None or
+            "WAITER_DEADLINE_OFF" not in results or results["WAITER_DEADLINE_OFF"] is None):
+        tree_off = results.get("WAITER_TREE_ENTRY_OFF")
         if tree_off is not None:
             # rb_node is 24 bytes, prio follows
             results["WAITER_PRIO_OFF"] = tree_off + 0x18
             results["WAITER_DEADLINE_OFF"] = tree_off + 0x20
-            print(f"\n  WAITER_PRIO_OFF (derived): 0x{tree_off + 0x18:X}")
-            print(f"  WAITER_DEADLINE_OFF (derived): 0x{tree_off + 0x20:X}")
+
+    for struct_name, size, member_count, fields in struct_reports:
+        if size is None:
+            print(f"\n{struct_name}: NOT FOUND")
+            continue
+        print(f"\n{struct_name} (size={size}, {member_count} members):")
+        print_offset_header()
+        for _, define_name in sorted(fields.items(), key=lambda x: x[1]):
+            print_offset_row(define_name, results.get(define_name), current.get(define_name))
 
     found = sum(1 for v in results.values() if v is not None)
-    total = sum(len(f) for f in FIELDS_NEEDED.values()) + 3  # +3 for special fields
+    total = sum(len(f) for f in FIELDS_NEEDED.values())
     print(f"\nExtracted: {found}/{total}")
 
 if __name__ == "__main__":

--- a/tools/extract_target.py
+++ b/tools/extract_target.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
-"""Extract target.h offsets from boot.img's embedded kallsyms table."""
+"""Extract target.h offsets from a kallsyms symbol table."""
 
-import struct, sys, re, os
+import argparse
+import os
+import re
+from pathlib import Path
 
 SYMBOLS_NEEDED = {
     "INIT_TASK_OFF": "init_task",
@@ -38,6 +41,37 @@ SPECIAL_RULES = {
     "SECURITY_HOOK_HEADS_OFF": ("security_hook_heads", 0),
 }
 
+OFFSET_FIELDS = {
+    "INIT_TASK_OFF": "off_init_task",
+    "INIT_CRED_OFF": "off_init_cred",
+    "INIT_UTS_NS_OFF": "off_init_uts_ns",
+    "EMPTY_ZERO_PAGE_OFF": "off_empty_zero_page",
+    "ROOT_TASK_GROUP_OFF": "off_root_task_group",
+    "SELINUX_ENFORCING_OFF": "off_selinux_enforcing",
+    "KPTR_RESTRICT_OFF": "off_kptr_restrict",
+    "SELINUX_BLOB_SIZES_OFF": "off_selinux_blob_sizes",
+    "SECURITY_HOOK_HEADS_OFF": "off_security_hook_heads",
+    "KMALLOC_CACHES_OFF": "off_kmalloc_caches",
+    "ANON_PIPE_BUF_OPS_OFF": "off_anon_pipe_buf_ops",
+    "ASHMEM_MISC_FOPS_OFF": "off_ashmem_misc_fops",
+    "ASHMEM_FOPS_OFF": "off_ashmem_fops",
+    "ASHMEM_IOCTL_OFF": "off_ashmem_ioctl",
+    "ASHMEM_COMPAT_IOCTL_OFF": "off_ashmem_compat_ioctl",
+    "ASHMEM_MMAP_OFF": "off_ashmem_mmap",
+    "ASHMEM_OPEN_OFF": "off_ashmem_open",
+    "ASHMEM_RELEASE_OFF": "off_ashmem_release",
+    "ASHMEM_SHOW_FDINFO_OFF": "off_ashmem_show_fdinfo",
+    "CONFIGFS_READ_ITER_OFF": "off_configfs_read_iter",
+    "CONFIGFS_BIN_WRITE_ITER_OFF": "off_configfs_bin_write_iter",
+    "COPY_SPLICE_READ_OFF": "off_copy_splice_read",
+    "NOOP_LLSEEK_OFF": "off_noop_llseek",
+    "CAP_CAPABLE_ACTIVE_OFF": "off_cap_capable_active",
+    "SLIDE_NFULNL_LOGGER_OFF": "off_slide_nfulnl_logger",
+    "SLIDE_LOGGERS_0_1_OFF": "off_slide_loggers_0_1",
+    "SLIDE_RANDOM_BOOT_ID_DATA_OFF": "off_slide_boot_id",
+    "SLIDE_SYSCTL_BOOTID_OFF": "off_slide_boot_id",
+}
+
 def find_kallsyms_in_kernel(data):
     """Find and parse the embedded kallsyms table in a raw kernel image."""
     # Look for the linux_banner string to find kernel base
@@ -63,18 +97,66 @@ def find_kallsyms_in_kernel(data):
     return None, banner
 
 def parse_kallsyms_file(path):
-    """Parse a kallsyms text file (from /proc/kallsyms or nm output)."""
+    """Parse ``address type name`` output from /proc/kallsyms, nm, or compact readelf."""
     symbols = {}
     with open(path, 'r') as f:
         for line in f:
             parts = line.strip().split()
             if len(parts) >= 3:
-                addr = int(parts[0], 16)
+                try:
+                    addr = int(parts[0], 16)
+                except ValueError:
+                    continue
                 typ = parts[1]
                 name = parts[2]
                 if addr > 0:
                     symbols[name] = (addr, typ)
     return symbols
+
+
+def parse_target_header(path):
+    """Parse hexadecimal *_OFF values from a target header."""
+    offsets = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            m = re.match(r'#define\s+(\w+_OFF)\s+(0x[0-9a-fA-F]+)', line)
+            if m:
+                offsets[m.group(1)] = int(m.group(2), 16)
+    return offsets
+
+
+def find_kernel_release_offsets(kernel_release):
+    """Find expected offsets for an exact uname -r in the device table."""
+    devices_dir = Path(__file__).resolve().parents[1] / "src" / "devices"
+    entry_pattern = re.compile(
+        r'OFFSETS_ENTRY\(\s*"([^"]+)"(?P<body>.*?)(?=\n\s*\),)',
+        re.DOTALL,
+    )
+    known_releases = []
+
+    for path in sorted(devices_dir.glob("*/offsets.h")):
+        contents = path.read_text(encoding="utf-8")
+        for entry in entry_pattern.finditer(contents):
+            release = entry.group(1)
+            known_releases.append(release)
+            if release != kernel_release:
+                continue
+
+            offsets = {}
+            for define_name, field_name in OFFSET_FIELDS.items():
+                field = re.search(
+                    rf'\.{re.escape(field_name)}\s*=\s*(0x[0-9a-fA-F]+|[0-9]+)',
+                    entry.group("body"),
+                )
+                if field:
+                    offsets[define_name] = int(field.group(1), 0)
+            return path.parent.name, offsets
+
+    known = "\n".join(f"  {release}" for release in known_releases)
+    raise ValueError(
+        f"kernel release is not in the device offset tables: {kernel_release}\n"
+        f"Known releases:\n{known or '  (none)'}"
+    )
 
 def find_symbol(symbols, sym_name):
     """Find a symbol by exact match, then substring match."""
@@ -162,7 +244,9 @@ def compute_offsets(symbols, kimage_base):
     if not addr:
         # Try Rust mangled misc device name
         for name, (a, typ) in symbols.items():
-            if "AshmemModule" in name and typ in ('d', 'D', 'b', 'B'):
+            if "AshmemModule" in name and typ in {
+                "d", "D", "b", "B", "OBJECT", "TLS", "COMMON"
+            }:
                 addr = a
                 break
     if addr:
@@ -184,18 +268,23 @@ def compute_offsets(symbols, kimage_base):
     return results
 
 def main():
-    # Check for existing kallsyms file
-    kallsyms_path = None
-    for p in ["C:/Android/kallsyms_fresh.txt", "C:/Android/kallsyms.txt"]:
-        if os.path.exists(p):
-            kallsyms_path = p
-            break
+    parser = argparse.ArgumentParser(
+        description="Extract target.h offsets from a kallsyms symbol table."
+    )
+    parser.add_argument(
+        "--kallsyms",
+        required=True,
+        help="path to a /proc/kallsyms dump or nm-format symbol file",
+    )
+    parser.add_argument(
+        "--kernel-release",
+        help="exact uname -r; compare against the matching src/devices entry",
+    )
+    args = parser.parse_args()
+    kallsyms_path = args.kallsyms
 
-    if not kallsyms_path:
-        print("ERROR: No kallsyms file found. Provide /proc/kallsyms dump or extract from vmlinux.")
-        print("  With root: adb shell su -c 'cat /proc/kallsyms' > kallsyms.txt")
-        print("  From boot.img: nm vmlinux > kallsyms.txt")
-        sys.exit(1)
+    if not os.path.isfile(kallsyms_path):
+        parser.error(f"kallsyms file does not exist: {kallsyms_path}")
 
     print(f"Using kallsyms: {kallsyms_path}")
     symbols = parse_kallsyms_file(kallsyms_path)
@@ -215,46 +304,57 @@ def main():
 
     results = compute_offsets(symbols, kimage_base)
 
-    # Read current target.h for comparison
-    target_h = os.path.join(os.path.dirname(__file__), "..", "src", "core", "target.h")
-    current = {}
-    if os.path.exists(target_h):
-        with open(target_h, encoding='utf-8') as f:
-            for line in f:
-                m = re.match(r'#define\s+(\w+_OFF)\s+(0x[0-9a-fA-F]+)', line)
-                if m:
-                    current[m.group(1)] = int(m.group(2), 16)
+    if args.kernel_release:
+        kernel_release = args.kernel_release.strip()
+        try:
+            target_name, baseline = find_kernel_release_offsets(kernel_release)
+        except (OSError, ValueError) as error:
+            parser.error(str(error))
+        baseline_label = "Expected"
+        print(f"Comparing against: {target_name} ({kernel_release})")
+    else:
+        target_h = os.path.join(os.path.dirname(__file__), "..", "src", "core", "target.h")
+        baseline = parse_target_header(target_h) if os.path.exists(target_h) else {}
+        baseline_label = "Default"
+        print("Comparing against: src/core/target.h (default fallback)")
 
     print("\n=== Extracted Offsets ===")
-    print(f"{'Define':<40} {'Extracted':>14} {'Current':>14} {'Match':>6}")
+    print(f"{'Define':<40} {'Extracted':>14} {baseline_label:>14} {'Match':>6}")
     print("-" * 80)
 
     all_match = True
-    for name in sorted(results.keys()):
-        extracted = results[name]
-        cur = current.get(name)
+    names = set(results)
+    if args.kernel_release:
+        names.update(baseline)
+    for name in sorted(names):
+        extracted = results.get(name)
+        expected = baseline.get(name)
 
         if extracted is not None:
             ext_str = f"0x{extracted:08X}"
         else:
             ext_str = "NOT FOUND"
 
-        if cur is not None:
-            cur_str = f"0x{cur:08X}"
+        if expected is not None:
+            expected_str = f"0x{expected:08X}"
         else:
-            cur_str = "N/A"
+            expected_str = "N/A"
 
-        if extracted is not None and cur is not None:
-            match = "OK" if extracted == cur else "DIFF!"
+        if extracted is not None and expected is not None:
+            match = "OK" if extracted == expected else "DIFF!"
             if match == "DIFF!":
                 all_match = False
+        elif extracted is None and expected == 0:
+            # A zero in a device entry means that the optional symbol/path is
+            # intentionally unavailable for that kernel.
+            match = "OK"
         elif extracted is None:
             match = "MISS"
             all_match = False
         else:
             match = "NEW"
 
-        print(f"{name:<40} {ext_str:>14} {cur_str:>14} {match:>6}")
+        print(f"{name:<40} {ext_str:>14} {expected_str:>14} {match:>6}")
 
     print(f"\n{'ALL MATCH' if all_match else 'DIFFERENCES FOUND'}")
 
@@ -287,18 +387,30 @@ def verify_offsets(results, symbols, kimage_base):
     print("\n=== Verification ===")
 
     # 1. Symbol type checks
+    data_types = {
+        "D", "d", "B", "b", "R", "r", "S", "s", "G", "g", "C", "c"
+    }
+    data_types_available = any(typ in data_types for _, typ in symbols.values())
     type_checks = {
-        "init_task": ("D", "B", "d", "b"),    # data/bss
-        "init_cred": ("D", "d"),               # data (initialized)
-        "selinux_state": ("B", "b"),            # bss
-        "loggers": ("D", "d"),                  # data
-        "noop_llseek": ("T", "t"),              # text (function)
-        "copy_splice_read": ("T", "t"),         # text
+        "init_task": ("D", "B", "d", "b", "OBJECT", "TLS", "COMMON"),
+        "init_cred": ("D", "d", "OBJECT", "TLS", "COMMON"),
+        "selinux_state": ("B", "b", "OBJECT", "TLS", "COMMON"),
+        "loggers": ("D", "d", "OBJECT", "TLS", "COMMON"),
+        "noop_llseek": ("T", "t", "FUNC", "IFUNC"),
+        "copy_splice_read": ("T", "t", "FUNC", "IFUNC"),
     }
     for sym_name, expected_types in type_checks.items():
         t = sym_type(sym_name)
         if t and t not in expected_types:
-            errors.append(f"  {sym_name}: type='{t}', expected one of {expected_types}")
+            if not data_types_available and sym_name in {
+                "init_task", "init_cred", "selinux_state", "loggers"
+            } and t in {"T", "t"}:
+                warnings.append(
+                    f"  {sym_name}: type='{t}' is unverified; symbol file has no "
+                    "data-symbol types (likely a reconstructed ELF with a merged WAX section)"
+                )
+            else:
+                errors.append(f"  {sym_name}: type='{t}', expected one of {expected_types}")
         elif t:
             print(f"  [OK] {sym_name} type='{t}'")
 

--- a/tools/kallsyms/GUIDE.md
+++ b/tools/kallsyms/GUIDE.md
@@ -1,0 +1,368 @@
+# Recover kernel symbols from an Android boot image
+
+This guide starts with the standard AOSP boot-image path. Try the simple path
+first: it is fairly robust for ordinary `boot.img` files, and it uses the
+repository's AOSP-compatible extractor, `vmlinux-to-elf`, and the host ELF
+symbol reader. Its host requirements are Python/`uv`, Git, and an ELF utility;
+Magisk and the Android NDK are reserved for the alternate image path.
+
+The workflow produces these files when `analysis` is used as the work
+directory:
+
+```text
+analysis/kernel       extracted raw or compressed kernel payload
+analysis/kernel.dtb   optional appended device tree blob
+analysis/vmlinux      reconstructed ELF
+analysis/kallsyms.txt compact address-sorted symbol list
+```
+
+The generated symbol list has the form `address TYPE name`, for example
+`ffff... FUNC noop_llseek`. This is the format consumed by
+`tools/extract_target.py`.
+
+## Simple path: standard AOSP `boot.img`
+
+Run these stages in order. The first failure tells you which decision to make;
+the alternate image-extraction path is documented below.
+
+### 1. Install the host tools
+
+On Debian or Ubuntu:
+
+```sh
+sudo apt update
+sudo apt install --yes curl git binutils
+```
+
+On Fedora:
+
+```sh
+sudo dnf install curl git binutils
+```
+
+On Arch:
+
+```sh
+sudo pacman -S --needed curl git binutils
+```
+
+You need Python 3.9 or newer and `uv`. Install `uv` using its official
+installer, then open a new shell if the installer asks you to refresh `PATH`:
+
+```sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
+command -v uv
+uv python install 3.12
+```
+
+`binutils` supplies `readelf` and `strings`. LLVM is also supported: set
+`READELF_PATH` to `llvm-readelf` when that is the ELF tool available on the
+host. On a host where `uv` selects a source build for one of its Python
+packages, install the ordinary host C compiler package (for example,
+`build-essential`); the Android NDK belongs to the alternate `magiskboot`
+build path.
+
+### 2. Prepare `vmlinux-to-elf`
+
+The reconstruction wrapper imports the upstream source from a local checkout.
+Clone it once and point `VMLINUX_TO_ELF_REPO_DIR` at that checkout:
+
+```sh
+mkdir -p "$HOME/repositories"
+git clone https://github.com/marin-m/vmlinux-to-elf.git \
+  "$HOME/repositories/vmlinux-to-elf"
+
+export VMLINUX_TO_ELF_REPO_DIR="$HOME/repositories/vmlinux-to-elf"
+export KALLSYMS_TOOLS_DIR="$HOME/repositories/ghostlock-oneplus/tools/kallsyms"
+```
+
+If the repository already exists, keep it and set the two variables to its
+actual locations. The `uv` metadata in `reconstruct_vmlinux.py` supplies and
+manages the Python dependencies for the upstream tool on demand.
+
+### 3. Extract the kernel
+
+Place the input image in the current directory or replace `boot.img` with its
+full path:
+
+```sh
+cd "$HOME/repositories/ghostlock-oneplus"
+mkdir -p analysis
+python3 "$KALLSYMS_TOOLS_DIR/extract_kernel.py" \
+  boot.img analysis/kernel \
+  --dtb-output analysis/kernel.dtb
+```
+
+For standard AOSP header versions 0 through 4, the extractor reads the kernel
+size and page layout, copies the kernel section, and separates a valid appended
+DTB when one is present. The kernel can remain compressed for the next stage.
+If you already use AOSP's `unpack_bootimg.py`, its extracted `kernel` can be
+used as the input to Step 4 instead.
+
+A successful run prints a line similar to:
+
+```text
+Extracted AOSP boot header v4 kernel: .../analysis/kernel
+```
+
+### 4. Reconstruct `vmlinux`
+
+```sh
+uv run --script "$KALLSYMS_TOOLS_DIR/reconstruct_vmlinux.py" \
+  analysis/kernel analysis/vmlinux
+```
+
+For an AArch64 kernel, if the reconstruction reports an architecture
+selection error, retry with the upstream overrides:
+
+```sh
+uv run --script "$KALLSYMS_TOOLS_DIR/reconstruct_vmlinux.py" \
+  analysis/kernel analysis/vmlinux \
+  --e-machine 183 --bit-size 64
+```
+
+Check the result when diagnosing a reconstruction failure:
+
+```sh
+file analysis/vmlinux
+readelf -h analysis/vmlinux
+```
+
+### 5. Export the symbol list
+
+```sh
+python3 "$KALLSYMS_TOOLS_DIR/export_kallsyms.py" \
+  analysis/vmlinux analysis/kallsyms.txt
+```
+
+The default exporter uses `readelf --symbols --wide` and writes ELF types such
+as `FUNC` and `OBJECT`. This preserves the distinction between code and data
+symbols needed by the offset extractor. If the host provides LLVM instead of
+GNU binutils, use:
+
+```sh
+READELF_PATH=/path/to/llvm-readelf \
+python3 "$KALLSYMS_TOOLS_DIR/export_kallsyms.py" \
+  analysis/vmlinux analysis/kallsyms.txt
+```
+
+When a `/proc/kallsyms`-like artifact is specifically required, export the
+kernel's embedded table as a separate file:
+
+```sh
+uv run --script "$KALLSYMS_TOOLS_DIR/find_kallsyms.py" \
+  analysis/kernel analysis/embedded-kallsyms.txt
+```
+
+Use `analysis/kallsyms.txt` for the default `extract_target.py` workflow; the
+embedded-table file is a separate representation of the same kernel symbols.
+
+### 6. Extract the target offsets
+
+For a device connected over ADB, get the exact kernel release and pass it to
+the extractor:
+
+```sh
+kernel_release=$(adb shell uname -r | tr -d '\r')
+python3 tools/extract_target.py \
+  --kallsyms analysis/kallsyms.txt \
+  --kernel-release "$kernel_release"
+```
+
+The release string must match the device's `uname -r` exactly. When working
+from the image alone, read the same value from the reconstructed kernel:
+
+```sh
+kernel_release=$(strings -a analysis/vmlinux \
+  | sed -n 's/^Linux version \([^ ]*\).*/\1/p' \
+  | head -n 1)
+python3 tools/extract_target.py \
+  --kallsyms analysis/kallsyms.txt \
+  --kernel-release "$kernel_release"
+```
+
+For a quick check on an uncompressed image, the banner may also be visible in
+the image itself:
+
+```sh
+strings -a boot.img \
+  | sed -n 's/^Linux version \([^ ]*\).*/\1/p' \
+  | head -n 1
+```
+
+On PowerShell, the running-device equivalent is:
+
+```powershell
+$kernelRelease = (adb shell uname -r).Trim()
+python tools\extract_target.py `
+  --kallsyms analysis\kallsyms.txt `
+  --kernel-release $kernelRelease
+```
+
+### 7. Extract BTF structure offsets
+
+When the raw kernel contains BTF, run the companion extractor against the same
+kernel payload:
+
+```sh
+python3 tools/extract_btf.py analysis/kernel
+```
+
+Use the `OK`, `MISS`, and `DIFF!` rows to decide which fields need review before
+adding a new device entry. A derived field can be reported as `MISS` in the
+raw BTF member list and still be printed later when the tool can derive it
+from a related member.
+
+## Optional one-command workflow
+
+After the staged path works, `kallsyms.py` can run the same extraction,
+reconstruction, and export steps together while preserving intermediates:
+
+```sh
+export MAGISK_REPO_DIR="$HOME/repositories/Magisk"
+export VMLINUX_TO_ELF_REPO_DIR="$HOME/repositories/vmlinux-to-elf"
+
+uv run --script "$KALLSYMS_TOOLS_DIR/kallsyms.py" \
+  "$HOME/repositories/ghostlock-oneplus/boot.img" \
+  "$HOME/repositories/ghostlock-oneplus/analysis/kallsyms.txt" \
+  --work-dir "$HOME/repositories/ghostlock-oneplus/analysis"
+```
+
+This wrapper prepares clean, matching source checkouts, runs preflight, and
+then executes the stages above. It also keeps the optional Magisk source
+checkout synchronized for the image-format fallback. The standard extractor
+remains the selected extractor when neither `--magiskboot` nor
+`MAGISKBOOT_PATH` is supplied.
+
+The wrapper writes the requested output atomically. Passing `--work-dir`
+keeps `kernel`, `kernel.dtb`, and `vmlinux`; if `--work-dir` is omitted, those
+intermediates are stored in a temporary directory and removed after the run.
+
+To use a different output location:
+
+```sh
+uv run --script "$KALLSYMS_TOOLS_DIR/kallsyms.py" \
+  /path/to/boot.img /path/to/kallsyms.txt \
+  --work-dir /path/to/analysis
+```
+
+The repository synchronizer fast-forwards only clean checkouts with the
+expected remote and a usable branch. It stops and reports the repository state
+when manual changes, a detached HEAD, a different remote, or divergent history
+needs attention.
+
+## When to use the alternate image path
+
+Try the simple AOSP path first. Move to `magiskboot` only when the image
+extractor reports one of these format-specific conditions:
+
+| Message or condition | Next step |
+| --- | --- |
+| `this is vendor_boot.img; its kernel normally comes from boot.img` | Locate the matching `boot.img`; `vendor_boot.img` normally carries vendor ramdisk/DTB data. |
+| `ANDROID! boot magic was not found` | Verify the file and, if it is a vendor-specific image, use `magiskboot`. |
+| `invalid legacy page size ...; use MAGISKBOOT_PATH for this image` | Use `magiskboot` to unpack the image. |
+| A known boot-image format is accepted by `magiskboot` while the standard parser rejects it | Use `magiskboot` for extraction, then continue with reconstruction and export. |
+
+Messages about a truncated file or a kernel section extending beyond the image
+indicate an incomplete or mismatched image. Re-obtain the exact `boot.img`
+before changing extraction tools.
+
+An architecture error from `vmlinux-to-elf` is a reconstruction setting issue;
+try `--e-machine 183 --bit-size 64` for AArch64 before changing image
+extractors. A `readelf` error should be investigated with `file` and
+`readelf -h` so the reconstruction output can be corrected first.
+
+## Alternate extraction with `magiskboot`
+
+Use an existing trusted host `magiskboot` executable when available:
+
+```sh
+export MAGISKBOOT_PATH=/path/to/magiskboot
+python3 "$KALLSYMS_TOOLS_DIR/extract_kernel.py" \
+  boot.img analysis/kernel \
+  --dtb-output analysis/kernel.dtb
+```
+
+`magiskboot unpack` also decompresses compressed kernels. After extraction,
+resume at [reconstruct `vmlinux`](#4-reconstruct-vmlinux) and continue through
+the simple path.
+
+If you need to build the executable, build the host target from a clean Magisk
+checkout. This is the alternate route that uses the Android NDK and Rust
+toolchain:
+
+```sh
+export MAGISK_REPO_DIR="$HOME/repositories/Magisk"
+export ANDROID_HOME="$HOME/Android/Sdk"
+
+git clone https://github.com/topjohnwu/Magisk.git "$MAGISK_REPO_DIR"
+(cd "$MAGISK_REPO_DIR" && ./build.py ndk)
+(cd "$MAGISK_REPO_DIR" && ./build.py native magiskboot)
+
+export MAGISKBOOT_PATH="$MAGISK_REPO_DIR/native/out/x86_64/magiskboot"
+```
+
+Magisk's native build check expects its ONDK under
+`$ANDROID_HOME/ndk/magisk`, with `ONDK_VERSION` set to `r30.1`. The `ndk` build
+step prepares that layout. Select the ABI directory containing the host
+executable; on Windows use the `.exe` build or run this alternate route in
+WSL.
+
+The optional preflight for this route is:
+
+```sh
+export VMLINUX_TO_ELF_REPO_DIR="$HOME/repositories/vmlinux-to-elf"
+uv run --script "$KALLSYMS_TOOLS_DIR/preflight.py" \
+  --boot-image boot.img \
+  --require-magiskboot \
+  --check-native-build
+```
+
+The all-in-one wrapper can select the same extractor explicitly:
+
+```sh
+uv run --script "$KALLSYMS_TOOLS_DIR/kallsyms.py" \
+  boot.img kallsyms.txt \
+  --work-dir analysis \
+  --magiskboot "$MAGISKBOOT_PATH"
+```
+
+## Windows
+
+The Python stages are cross-platform. Install Git, `uv`, and LLVM; use
+`llvm-readelf.exe` through `READELF_PATH`. In PowerShell, the simple path is:
+
+```powershell
+uv python install 3.12
+
+$env:KALLSYMS_TOOLS_DIR = "$PWD\tools\kallsyms"
+$env:VMLINUX_TO_ELF_REPO_DIR = "$HOME\src\vmlinux-to-elf"
+
+python "$env:KALLSYMS_TOOLS_DIR\extract_kernel.py" `
+  "$PWD\boot.img" "$PWD\analysis\kernel" `
+  --dtb-output "$PWD\analysis\kernel.dtb"
+
+uv run --script "$env:KALLSYMS_TOOLS_DIR\reconstruct_vmlinux.py" `
+  "$PWD\analysis\kernel" "$PWD\analysis\vmlinux"
+
+$env:READELF_PATH = "C:\Program Files\LLVM\bin\llvm-readelf.exe"
+python "$env:KALLSYMS_TOOLS_DIR\export_kallsyms.py" `
+  "$PWD\analysis\vmlinux" "$PWD\analysis\kallsyms.txt"
+```
+
+Use `python` rather than `python3` in PowerShell. The Magisk native fallback
+is usually simplest to build under WSL; point `MAGISKBOOT_PATH` at the
+resulting host executable when using it.
+
+## Files in this workflow
+
+| File | Purpose |
+| --- | --- |
+| `extract_kernel.py` | Extract the kernel payload from a standard AOSP image or with `magiskboot`. |
+| `reconstruct_vmlinux.py` | Run the synchronized `vmlinux-to-elf` source through `uv`. |
+| `export_kallsyms.py` | Export an address-sorted compact symbol list. |
+| `find_kallsyms.py` | Locate the kernel's embedded `/proc/kallsyms`-like table when that artifact is required. |
+| `kallsyms.py` | Run repository preparation, preflight, extraction, reconstruction, and export together. |
+| `preflight.py` | Check the host and optional native fallback prerequisites without changing files. |
+| `bootstrap.py` | Prepare the source repositories used by the one-command workflow. |
+| `common.py` | Shared path, subprocess, and atomic-output helpers. |

--- a/tools/kallsyms/bootstrap.py
+++ b/tools/kallsyms/bootstrap.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Clone or fast-forward the source repositories used by the workflow."""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from common import (
+    canonical_git_url,
+    configured_url,
+    output_of,
+    required_env,
+    run,
+)
+
+
+MAGISK_URL = "https://github.com/topjohnwu/Magisk.git"
+VMLINUX_TO_ELF_URL = "https://github.com/marin-m/vmlinux-to-elf.git"
+
+
+def git_output(repo: Path, *arguments: str, check: bool = True) -> str:
+    return output_of(["git", "-C", repo, *arguments], check=check)
+
+
+def is_git_worktree(path: Path) -> bool:
+    result = run(
+        ["git", "-C", path, "rev-parse", "--is-inside-work-tree"],
+        capture=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def assert_clean(repo: Path) -> None:
+    status = git_output(repo, "status", "--porcelain", "--untracked-files=all")
+    if status:
+        raise RuntimeError(
+            f"refusing to update dirty repository {repo}; commit, stash, or remove its changes first"
+        )
+
+
+def sync_repository(path: Path, url: str, *, submodules: bool) -> None:
+    """Clone a missing repo; otherwise only fetch and fast-forward it."""
+
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Cloning {url} -> {path}")
+        command = ["git", "clone"]
+        if submodules:
+            command.append("--recurse-submodules")
+        command.extend([url, path])
+        run(command)
+    else:
+        if not path.is_dir():
+            raise RuntimeError(f"repository path exists but is not a directory: {path}")
+        if not is_git_worktree(path):
+            if any(path.iterdir()):
+                raise RuntimeError(
+                    f"refusing to clone over a non-empty non-Git directory: {path}"
+                )
+            raise RuntimeError(
+                f"{path} is empty but not a Git worktree; remove it yourself or choose another path"
+            )
+
+        origin = git_output(path, "config", "--get", "remote.origin.url", check=False)
+        if not origin:
+            raise RuntimeError(f"{path} has no origin remote")
+        if canonical_git_url(origin) != canonical_git_url(url):
+            raise RuntimeError(
+                f"{path} origin is {origin!r}, expected {url!r}; refusing to update the wrong repository"
+            )
+
+        assert_clean(path)
+        branch = git_output(path, "symbolic-ref", "--quiet", "--short", "HEAD", check=False)
+        if not branch:
+            raise RuntimeError(f"{path} is in detached-HEAD state; check out a branch before retrying")
+
+        print(f"Fetching {path}")
+        run(["git", "-C", path, "fetch", "--prune", "origin"])
+
+        upstream = git_output(
+            path,
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{u}",
+            check=False,
+        )
+        if upstream and not upstream.startswith("origin/"):
+            raise RuntimeError(
+                f"{path} tracks non-origin upstream {upstream!r}; refusing to merge another remote"
+            )
+        if not upstream:
+            candidate = f"origin/{branch}"
+            exists = run(
+                ["git", "-C", path, "rev-parse", "--verify", f"refs/remotes/{candidate}"],
+                capture=True,
+                check=False,
+            )
+            if exists.returncode != 0:
+                raise RuntimeError(
+                    f"cannot determine an upstream for {path} branch {branch!r}; set one explicitly"
+                )
+            upstream = candidate
+
+        print(f"Fast-forwarding {path} to {upstream}")
+        run(["git", "-C", path, "merge", "--ff-only", upstream])
+
+    if submodules:
+        print(f"Updating submodules in {path}")
+        run(["git", "-C", path, "submodule", "update", "--init", "--recursive"])
+    assert_clean(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Clone or fast-forward the analysis repositories and prepare vmlinux-to-elf."
+    )
+    parser.parse_args()
+
+    if sys.version_info < (3, 9):
+        raise RuntimeError(
+            f"Python 3.9 or newer is required by vmlinux-to-elf (found {sys.version.split()[0]})"
+        )
+
+    magisk = required_env("MAGISK_REPO_DIR")
+    vmlinux_to_elf = required_env("VMLINUX_TO_ELF_REPO_DIR")
+    magisk_url = configured_url("MAGISK_REPO_URL", MAGISK_URL)
+    vmlinux_url = configured_url("VMLINUX_TO_ELF_REPO_URL", VMLINUX_TO_ELF_URL)
+
+    sync_repository(magisk, magisk_url, submodules=True)
+    sync_repository(vmlinux_to_elf, vmlinux_url, submodules=False)
+    print()
+    print("Bootstrap complete.")
+    print(f"  Magisk:          {magisk}")
+    print(f"  vmlinux-to-elf:  {vmlinux_to_elf}")
+    print("  Python/dependencies: managed per invocation by uv script metadata")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"bootstrap: error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/kallsyms/common.py
+++ b/tools/kallsyms/common.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Small standard-library helpers shared by the gist scripts."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Iterator, Mapping, Optional, Sequence, Union
+
+
+PathLike = Union[str, os.PathLike[str]]
+
+
+def expanded_path(value: PathLike) -> Path:
+    """Expand a user-supplied path without requiring it to exist."""
+
+    return Path(os.path.expandvars(os.path.expanduser(os.fspath(value)))).resolve()
+
+
+def required_env(name: str) -> Path:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} is required; set it to the repository path")
+    return expanded_path(value)
+
+
+def configured_url(env_name: str, default: str) -> str:
+    return os.environ.get(env_name, default).strip()
+
+
+def canonical_git_url(value: str) -> str:
+    """Normalize the harmless URL differences commonly produced by Git."""
+
+    return value.strip().rstrip("/").removesuffix(".git").lower()
+
+
+def command_path(value: str) -> Optional[str]:
+    """Resolve either a command name or an explicit executable path."""
+
+    expanded = os.path.expandvars(os.path.expanduser(value))
+    if os.path.dirname(expanded):
+        candidate = Path(expanded)
+        return str(candidate) if candidate.is_file() else None
+    return shutil.which(expanded)
+
+
+def first_command(*names: str) -> Optional[str]:
+    for name in names:
+        found = command_path(name)
+        if found:
+            return found
+    return None
+
+
+def run(
+    command: Sequence[PathLike],
+    *,
+    cwd: Optional[PathLike] = None,
+    env: Optional[Mapping[str, str]] = None,
+    capture: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command without invoking a shell."""
+
+    argv = [os.fspath(part) for part in command]
+    return subprocess.run(
+        argv,
+        cwd=os.fspath(cwd) if cwd is not None else None,
+        env=dict(env) if env is not None else None,
+        text=True,
+        capture_output=capture,
+        check=check,
+    )
+
+
+def output_of(
+    command: Sequence[PathLike],
+    *,
+    cwd: Optional[PathLike] = None,
+    env: Optional[Mapping[str, str]] = None,
+    check: bool = True,
+) -> str:
+    return run(command, cwd=cwd, env=env, capture=True, check=check).stdout.strip()
+
+
+def python_env(repo: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    old = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(repo) + (os.pathsep + old if old else "")
+    return env
+
+
+def ensure_file(path: Path, description: str) -> None:
+    if not path.is_file():
+        raise RuntimeError(f"{description} does not exist or is not a file: {path}")
+    if path.stat().st_size == 0:
+        raise RuntimeError(f"{description} is empty: {path}")
+
+
+@contextlib.contextmanager
+def atomic_output(path: Path, *, suffix: str = ".tmp") -> Iterator[Path]:
+    """Yield a temporary sibling and atomically replace the requested path."""
+
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=suffix, dir=path.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        yield temporary
+        ensure_file(temporary, "temporary output")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/tools/kallsyms/export_kallsyms.py
+++ b/tools/kallsyms/export_kallsyms.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Export vmlinux symbols in the compact format consumed by extract_target.py."""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from common import atomic_output, command_path, ensure_file, expanded_path, first_command
+
+
+def resolve_tool(
+    override: Optional[str],
+    environment_name: str,
+    candidates: tuple[str, ...],
+    description: str,
+) -> str:
+    selected = override or os.environ.get(environment_name)
+    resolved = command_path(selected) if selected else first_command(*candidates)
+    if resolved is None:
+        choices = ", ".join(candidates)
+        raise RuntimeError(f"{description} is not available ({choices})")
+    return resolved
+
+
+def export_nm(vmlinux: Path, output: Path, executable: str) -> None:
+    with atomic_output(output) as temporary:
+        with temporary.open("w", encoding="utf-8", newline="") as stream:
+            result = subprocess.run(
+                [executable, "-n", vmlinux],
+                stdout=stream,
+                text=True,
+                check=False,
+            )
+        if result.returncode:
+            raise RuntimeError(f"{executable} exited with status {result.returncode}")
+
+
+def export_readelf(vmlinux: Path, output: Path, executable: str) -> int:
+    result = subprocess.run(
+        [executable, "--symbols", "--wide", vmlinux],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or f"exited with status {result.returncode}"
+        raise RuntimeError(f"{executable}: {detail}")
+
+    symbols: list[tuple[int, int, str, str]] = []
+    for order, line in enumerate(result.stdout.splitlines()):
+        fields = line.split()
+        # readelf's table is:
+        # Num: Value Size Type Bind Vis Ndx Name
+        if len(fields) < 8 or not fields[0].endswith(":"):
+            continue
+        try:
+            address = int(fields[1], 16)
+        except ValueError:
+            continue
+        name = fields[7]
+        if name:
+            symbols.append((address, order, fields[3], name))
+
+    if not symbols:
+        detail = result.stderr.strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"{executable} produced no ELF symbols{suffix}")
+
+    symbols.sort(key=lambda item: (item[0], item[1]))
+    with atomic_output(output) as temporary:
+        with temporary.open("w", encoding="utf-8", newline="") as stream:
+            for address, _, symbol_type, name in symbols:
+                stream.write(f"{address:016x} {symbol_type} {name}\n")
+    return len(symbols)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Export vmlinux symbols; compact readelf format is the default."
+    )
+    parser.add_argument("vmlinux", type=Path, help="reconstructed ELF vmlinux")
+    parser.add_argument("output", type=Path, help="symbol-list output, usually kallsyms.txt")
+    parser.add_argument(
+        "--format",
+        choices=("readelf", "nm"),
+        default=None,
+        help="symbol type convention (default: readelf; nm is the compatibility fallback)",
+    )
+    parser.add_argument(
+        "--readelf",
+        help="readelf or llvm-readelf executable; defaults to READELF_PATH, readelf, then llvm-readelf",
+    )
+    parser.add_argument(
+        "--nm",
+        help="nm or llvm-nm executable; supplying this without --format selects nm output",
+    )
+    args = parser.parse_args()
+
+    vmlinux = expanded_path(args.vmlinux)
+    output = expanded_path(args.output)
+    ensure_file(vmlinux, "vmlinux")
+    if args.nm and args.readelf:
+        parser.error("--nm and --readelf cannot be used together")
+    if args.nm and args.format == "readelf":
+        parser.error("--nm selects nm output; omit --format or use --format nm")
+    selected_format = args.format or ("nm" if args.nm else "readelf")
+    if selected_format == "readelf":
+        executable = resolve_tool(
+            args.readelf,
+            "READELF_PATH",
+            ("readelf", "llvm-readelf"),
+            "ELF symbol reader",
+        )
+        count = export_readelf(vmlinux, output, executable)
+        print(f"Exported {count} symbols with {executable} (readelf format): {output}")
+    else:
+        if args.readelf:
+            parser.error("--readelf is only valid with --format readelf")
+        executable = resolve_tool(
+            args.nm,
+            "NM_PATH",
+            ("nm", "llvm-nm"),
+            "nm symbol dumper",
+        )
+        export_nm(vmlinux, output, executable)
+        print(f"Exported symbols with {executable} (nm format): {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"export_kallsyms: error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/kallsyms/extract_kernel.py
+++ b/tools/kallsyms/extract_kernel.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Extract a boot image's kernel payload.
+
+The default path parses standard AOSP boot images with the Python standard
+library.  MAGISKBOOT_PATH can be supplied for formats that are outside that
+small parser; magiskboot also performs the decompression that its unpack
+command normally performs.
+"""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+from common import atomic_output, command_path, ensure_file, expanded_path, run
+
+
+ANDROID_MAGIC = b"ANDROID!"
+VENDOR_BOOT_MAGIC = b"VNDRBOOT"
+FDT_MAGIC = b"\xd0\x0d\xfe\xed"
+FDT_BEGIN_NODE = 1
+MIN_NON_EMPTY_DTB_SIZE = 0x48
+
+
+def u32_le(data: bytes, offset: int) -> int:
+    if offset < 0 or offset + 4 > len(data):
+        raise RuntimeError(f"boot image is too small to read offset 0x{offset:x}")
+    return int.from_bytes(data[offset : offset + 4], "little")
+
+
+def u32_be(data: bytes, offset: int) -> int:
+    if offset < 0 or offset + 4 > len(data):
+        raise RuntimeError(f"DTB is too small to read offset 0x{offset:x}")
+    return int.from_bytes(data[offset : offset + 4], "big")
+
+
+def plausible_legacy_page_size(page_size: int) -> bool:
+    return 512 <= page_size <= 1024 * 1024 and page_size & (page_size - 1) == 0
+
+
+def detect_header_version(data: bytes, forced: Optional[int]) -> int:
+    if forced is not None:
+        return forced
+
+    candidate = u32_le(data, 40)
+    # A v3/v4 header has a fixed 4096-byte page and reserved bytes where a
+    # legacy header stores page_size.  A legacy image's page_size wins when
+    # the same offset happens to contain the value 3 or 4.
+    if candidate in (3, 4):
+        legacy_page_size = u32_le(data, 36)
+        v3_header_size = u32_le(data, 20)
+        if not plausible_legacy_page_size(legacy_page_size) and 44 <= v3_header_size <= 4096:
+            return candidate
+        return 0
+    return candidate if candidate in (1, 2) else 0
+
+
+def valid_dtb(data: bytes, offset: int) -> bool:
+    if offset < 0 or offset + 40 > len(data) or data[offset : offset + 4] != FDT_MAGIC:
+        return False
+
+    total_size = u32_be(data, offset + 4)
+    off_struct = u32_be(data, offset + 8)
+    off_strings = u32_be(data, offset + 12)
+    off_mem_rsvmap = u32_be(data, offset + 16)
+    version = u32_be(data, offset + 20)
+    last_comp_version = u32_be(data, offset + 24)
+    size_strings = u32_be(data, offset + 32)
+    size_struct = u32_be(data, offset + 36)
+
+    if total_size <= MIN_NON_EMPTY_DTB_SIZE or offset + total_size > len(data):
+        return False
+    if not 16 <= version <= 21 or last_comp_version > version:
+        return False
+    if off_mem_rsvmap + 16 > total_size:
+        return False
+    if off_struct + size_struct > total_size or off_strings + size_strings > total_size:
+        return False
+
+    struct_start = offset + off_struct
+    if struct_start + 4 > offset + total_size:
+        return False
+    if u32_be(data, struct_start) != FDT_BEGIN_NODE:
+        return False
+    try:
+        name_end = data.index(b"\0", struct_start + 4, offset + total_size)
+    except ValueError:
+        return False
+    return name_end < offset + total_size
+
+
+def find_dtb_offset(kernel: bytes) -> Optional[int]:
+    search_from = 0
+    while True:
+        relative = kernel.find(FDT_MAGIC, search_from)
+        if relative < 0:
+            return None
+        if relative > 0 and valid_dtb(kernel, relative):
+            return relative
+        search_from = relative + len(FDT_MAGIC)
+
+
+def parse_aosp_kernel(data: bytes, forced_version: Optional[int]) -> Tuple[bytes, Optional[bytes], int]:
+    magic_offset = data.find(ANDROID_MAGIC)
+    if magic_offset < 0:
+        if data.startswith(VENDOR_BOOT_MAGIC):
+            raise RuntimeError(
+                "this is vendor_boot.img; its kernel normally comes from boot.img, not vendor_boot.img"
+            )
+        raise RuntimeError("ANDROID! boot magic was not found")
+
+    header = data[magic_offset:]
+    if len(header) < 44:
+        raise RuntimeError("AOSP boot header is truncated")
+    version = detect_header_version(header, forced_version)
+    if version >= 3:
+        page_size = 4096
+    else:
+        page_size = u32_le(header, 36)
+        if not plausible_legacy_page_size(page_size):
+            raise RuntimeError(
+                f"invalid legacy page size {page_size}; use MAGISKBOOT_PATH for this image"
+            )
+
+    kernel_size = u32_le(header, 8)
+    kernel_start = magic_offset + page_size
+    kernel_end = kernel_start + kernel_size
+    if kernel_size == 0:
+        raise RuntimeError("boot image contains an empty kernel section")
+    if kernel_start > len(data) or kernel_end > len(data):
+        raise RuntimeError(
+            f"kernel section [{kernel_start}, {kernel_end}) extends past the {len(data)}-byte image"
+        )
+
+    kernel = data[kernel_start:kernel_end]
+    dtb_offset = find_dtb_offset(kernel)
+    if dtb_offset is None:
+        return kernel, None, version
+    return kernel[:dtb_offset], kernel[dtb_offset:], version
+
+
+def extract_with_magiskboot(
+    image: Path, output: Path, dtb_output: Optional[Path], magiskboot: str
+) -> None:
+    resolved = command_path(magiskboot)
+    if resolved is None:
+        raise RuntimeError(f"MAGISKBOOT_PATH is not an executable file: {magiskboot}")
+
+    with tempfile.TemporaryDirectory(prefix="magiskboot-unpack-") as temporary_dir:
+        work = Path(temporary_dir)
+        run([resolved, "unpack", image], cwd=work)
+        kernel = work / "kernel"
+        ensure_file(kernel, "magiskboot's kernel output")
+        with atomic_output(output) as temporary:
+            shutil.copyfile(kernel, temporary)
+
+        if dtb_output is not None:
+            kernel_dtb = work / "kernel_dtb"
+            if kernel_dtb.is_file() and kernel_dtb.stat().st_size:
+                with atomic_output(dtb_output) as temporary:
+                    shutil.copyfile(kernel_dtb, temporary)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract the kernel payload from an Android boot image.")
+    parser.add_argument("image", type=Path, help="boot.img or another supported boot image")
+    parser.add_argument("output", type=Path, help="raw/compressed kernel output")
+    parser.add_argument("--dtb-output", type=Path, help="optional output for an appended kernel DTB")
+    parser.add_argument(
+        "--magiskboot",
+        help="host magiskboot executable; defaults to MAGISKBOOT_PATH when set",
+    )
+    parser.add_argument(
+        "--header-version",
+        type=int,
+        choices=range(5),
+        help="override AOSP header detection (0 through 4)",
+    )
+    args = parser.parse_args()
+
+    image = expanded_path(args.image)
+    output = expanded_path(args.output)
+    dtb_output = expanded_path(args.dtb_output) if args.dtb_output else None
+    ensure_file(image, "boot image")
+
+    magiskboot = args.magiskboot or os.environ.get("MAGISKBOOT_PATH")
+    if magiskboot:
+        extract_with_magiskboot(image, output, dtb_output, magiskboot)
+        print(f"Extracted kernel with magiskboot: {output}")
+        if dtb_output and dtb_output.is_file():
+            print(f"Extracted appended DTB: {dtb_output}")
+        return 0
+
+    data = image.read_bytes()
+    kernel, dtb, version = parse_aosp_kernel(data, args.header_version)
+    with atomic_output(output) as temporary:
+        temporary.write_bytes(kernel)
+    if dtb_output is not None and dtb is not None:
+        with atomic_output(dtb_output) as temporary:
+            temporary.write_bytes(dtb)
+
+    print(f"Extracted AOSP boot header v{version} kernel: {output}")
+    if dtb is not None:
+        print(f"Extracted appended DTB: {dtb_output or '(not saved; pass --dtb-output to keep it)'}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"extract_kernel: error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/kallsyms/find_kallsyms.py
+++ b/tools/kallsyms/find_kallsyms.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Extract the kernel's embedded kallsyms table in /proc/kallsyms-like form."""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "lz4",
+#   "zstandard>=0.25.0",
+#   "minilzo>=1.2",
+#   "peewee>=3.17",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import List, Union
+
+from common import ensure_file, expanded_path, python_env, required_env, run
+
+
+MODULE = "vmlinux_to_elf.scripts.kallsyms_finder"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract embedded kallsyms from a kernel payload."
+    )
+    parser.add_argument("kernel", type=Path, help="extracted raw/compressed kernel")
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="output file; unlike upstream, no .kallsyms suffix is added",
+    )
+    parser.add_argument("--bit-size", choices=("32", "64"), help="override kernel bitness")
+    parser.add_argument("--base-address", help="kernel base address in hexadecimal")
+    parser.add_argument("--use-absolute", action="store_true", help="pass --use-absolute")
+    args = parser.parse_args()
+
+    kernel = expanded_path(args.kernel)
+    output = expanded_path(args.output)
+    ensure_file(kernel, "kernel input")
+    repo = required_env("VMLINUX_TO_ELF_REPO_DIR")
+    if not repo.is_dir():
+        raise RuntimeError(f"VMLINUX_TO_ELF_REPO_DIR is not a directory: {repo}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".kallsyms", dir=output.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    command: List[Union[str, os.PathLike[str]]] = [
+        sys.executable,
+        "-m",
+        MODULE,
+        kernel,
+        "--output",
+        temporary,
+    ]
+    if args.bit_size is not None:
+        command.extend(["--bit-size", args.bit_size])
+    if args.base_address is not None:
+        command.extend(["--base-address", args.base_address])
+    if args.use_absolute:
+        command.append("--use-absolute")
+
+    try:
+        result = run(command, env=python_env(repo), check=False)
+        if result.returncode:
+            raise RuntimeError(f"kallsyms-finder exited with status {result.returncode}")
+        ensure_file(temporary, "embedded kallsyms output")
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    print(f"Extracted embedded kallsyms: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"find_kallsyms: error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/kallsyms/kallsyms.py
+++ b/tools/kallsyms/kallsyms.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Run the complete boot.img -> kallsyms.txt workflow."""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable, Optional
+
+from common import command_path, ensure_file, expanded_path, run
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def run_uv_script(script_name: str, arguments: Iterable[object]) -> None:
+    uv = command_path("uv")
+    if uv is None:
+        raise RuntimeError("uv is not on PATH; install uv before running this workflow")
+
+    script = SCRIPT_DIR / script_name
+    command = [uv, "run", "--script", script]
+    command.extend(arguments)
+    print(f"== {script_name} ==", flush=True)
+    result = run(command, cwd=SCRIPT_DIR, check=False)
+    if result.returncode:
+        raise RuntimeError(f"{script_name} failed with status {result.returncode}")
+
+
+def run_pipeline(boot_image: Path, output: Path, work_dir: Path, magiskboot: Optional[str]) -> None:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    kernel = work_dir / "kernel"
+    kernel_dtb = work_dir / "kernel.dtb"
+    vmlinux = work_dir / "vmlinux"
+
+    if magiskboot:
+        os.environ["MAGISKBOOT_PATH"] = magiskboot
+
+    run_uv_script("bootstrap.py", ())
+
+    preflight_arguments = ["--boot-image", boot_image]
+    if magiskboot:
+        preflight_arguments.append("--require-magiskboot")
+    run_uv_script("preflight.py", preflight_arguments)
+
+    run_uv_script(
+        "extract_kernel.py",
+        [boot_image, kernel, "--dtb-output", kernel_dtb],
+    )
+    run_uv_script("reconstruct_vmlinux.py", [kernel, vmlinux])
+    run_uv_script("export_kallsyms.py", [vmlinux, output])
+
+    print()
+    print(f"Completed: {output}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Automate boot.img extraction, vmlinux reconstruction, and kallsyms export."
+    )
+    parser.add_argument(
+        "boot_image",
+        type=Path,
+        nargs="?",
+        default=Path("boot.img"),
+        help="input Android boot image (default: boot.img)",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        default=Path("kallsyms.txt"),
+        help="compact readelf-format symbol output (default: kallsyms.txt)",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        help="preserve kernel/vmlinux intermediates in this directory",
+    )
+    parser.add_argument(
+        "--magiskboot",
+        help="use a host magiskboot executable for extraction (troubleshooting fallback)",
+    )
+    args = parser.parse_args()
+
+    boot_image = expanded_path(args.boot_image)
+    output = expanded_path(args.output)
+    ensure_file(boot_image, "boot image")
+
+    if args.work_dir:
+        work_dir = expanded_path(args.work_dir)
+        run_pipeline(boot_image, output, work_dir, args.magiskboot)
+        print(f"Intermediate files: {work_dir}")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="kallsyms-work-") as temporary:
+        run_pipeline(boot_image, output, Path(temporary), args.magiskboot)
+    print("Intermediate files removed; pass --work-dir to keep them")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"kallsyms: error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/kallsyms/preflight.py
+++ b/tools/kallsyms/preflight.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Read-only checks for the kernel-symbol recovery workflow."""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Callable
+
+from common import (
+    canonical_git_url,
+    command_path,
+    configured_url,
+    expanded_path,
+    first_command,
+    output_of,
+    required_env,
+    run,
+)
+
+
+MAGISK_URL = "https://github.com/topjohnwu/Magisk.git"
+VMLINUX_TO_ELF_URL = "https://github.com/marin-m/vmlinux-to-elf.git"
+MAGISK_ONDK_VERSION = "r30.1"
+
+
+class Report:
+    def __init__(self) -> None:
+        self.failures = 0
+        self.warnings = 0
+
+    def ok(self, label: str, detail: str = "") -> None:
+        print(f"PASS  {label}{': ' + detail if detail else ''}")
+
+    def warn(self, label: str, detail: str) -> None:
+        self.warnings += 1
+        print(f"WARN  {label}: {detail}")
+
+    def fail(self, label: str, detail: str) -> None:
+        self.failures += 1
+        print(f"FAIL  {label}: {detail}")
+
+    def check(self, label: str, callback: Callable[[], str], *, required: bool = True) -> None:
+        try:
+            detail = callback()
+        except (OSError, RuntimeError, ValueError) as error:
+            if required:
+                self.fail(label, str(error))
+            else:
+                self.warn(label, str(error))
+        else:
+            self.ok(label, detail)
+
+
+def git_output(repo: Path, *arguments: str, check: bool = True) -> str:
+    return output_of(["git", "-C", repo, *arguments], check=check)
+
+
+def check_command(name: str) -> Callable[[], str]:
+    def inner() -> str:
+        found = command_path(name)
+        if found is None:
+            raise RuntimeError("not found on PATH")
+        return found
+
+    return inner
+
+
+def existing_directory(path: Path) -> str:
+    if not path.is_dir():
+        raise RuntimeError("directory not found")
+    return str(path)
+
+
+def check_repo(path: Path, label: str, expected_url: str, *, submodules: bool, report: Report) -> None:
+    report.check(f"{label} exists", lambda: existing_directory(path))
+    if not path.is_dir():
+        return
+
+    is_worktree = run(
+        ["git", "-C", path, "rev-parse", "--is-inside-work-tree"],
+        capture=True,
+        check=False,
+    )
+    if is_worktree.returncode != 0 or is_worktree.stdout.strip() != "true":
+        report.fail(f"{label} is a Git worktree", str(path))
+        return
+    report.ok(f"{label} is a Git worktree", str(path))
+
+    origin = git_output(path, "config", "--get", "remote.origin.url", check=False)
+    if not origin:
+        report.fail(f"{label} origin", "remote.origin.url is not configured")
+    elif canonical_git_url(origin) != canonical_git_url(expected_url):
+        report.fail(f"{label} origin", f"found {origin!r}; expected {expected_url!r}")
+    else:
+        report.ok(f"{label} origin", origin)
+
+    status = git_output(path, "status", "--porcelain", "--untracked-files=all", check=False)
+    if status:
+        report.fail(f"{label} clean checkout", "working tree has changes or untracked files")
+    else:
+        report.ok(f"{label} clean checkout")
+
+    branch = git_output(path, "symbolic-ref", "--quiet", "--short", "HEAD", check=False)
+    if branch:
+        report.ok(f"{label} branch", branch)
+    else:
+        report.fail(f"{label} branch", "detached HEAD")
+
+    if submodules:
+        submodule_status = git_output(path, "submodule", "status", "--recursive", check=False)
+        bad = [line for line in submodule_status.splitlines() if line[:1] in "-+U"]
+        if bad:
+            report.fail(f"{label} submodules", "one or more submodules are missing or mismatched")
+        else:
+            report.ok(f"{label} submodules", "initialized and at the recorded commits")
+
+    if label == "Magisk repository":
+        native_boot = path / "native" / "src" / "boot"
+        report.check("Magisk native boot sources", lambda: existing_directory(native_boot))
+
+
+def uv_script_check(script: Path, *arguments: str) -> str:
+    uv = first_command("uv")
+    if uv is None:
+        raise RuntimeError("uv is not on PATH")
+    result = run(
+        [uv, "run", "--script", script, *arguments],
+        cwd=script.parent,
+        capture=True,
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(detail or f"exited with status {result.returncode}")
+    return "uv selected a compatible Python and resolved the script environment"
+
+
+def check_vmlinux_environment(script_dir: Path, report: Report) -> None:
+    script = script_dir / "reconstruct_vmlinux.py"
+    report.check("uv reconstruction environment", lambda: uv_script_check(script, "--check-upstream"))
+    embedded_script = script_dir / "find_kallsyms.py"
+    report.check(
+        "uv embedded-kallsyms environment",
+        lambda: uv_script_check(embedded_script, "--help"),
+    )
+
+
+def check_host_compiler(report: Report, *, required: bool) -> None:
+    compiler = first_command("cc", "gcc", "clang", "cl")
+    if compiler is None:
+        detail = "cc, gcc, clang, or cl is not on PATH"
+        if required:
+            report.fail("host C compiler", detail)
+        else:
+            report.warn("host C compiler", detail + "; uv may still succeed if all wheels are available")
+    else:
+        report.ok("host C compiler", compiler)
+
+
+def check_native_build(report: Report) -> None:
+    check_host_compiler(report, required=True)
+
+    sdk_value = os.environ.get("ANDROID_HOME") or os.environ.get("ANDROID_SDK_ROOT")
+    if not sdk_value:
+        report.fail("Android SDK", "set ANDROID_HOME or ANDROID_SDK_ROOT")
+        return
+    sdk = expanded_path(sdk_value)
+    report.check("Android SDK", lambda: existing_directory(sdk))
+
+    ndk = sdk / "ndk" / "magisk"
+    report.check("Magisk ONDK", lambda: existing_directory(ndk))
+
+    version_file = ndk / "ONDK_VERSION"
+    def ondk_version() -> str:
+        if not version_file.is_file():
+            raise RuntimeError(f"missing {version_file}")
+        actual = version_file.read_text(encoding="utf-8").strip()
+        if actual != MAGISK_ONDK_VERSION:
+            raise RuntimeError(f"found {actual!r}; expected {MAGISK_ONDK_VERSION!r}")
+        return actual
+
+    report.check("Magisk ONDK version", ondk_version)
+
+    ndk_build_candidates = [ndk / "ndk-build"]
+    if os.name == "nt":
+        ndk_build_candidates.insert(0, ndk / "ndk-build.cmd")
+    ndk_build = next((candidate for candidate in ndk_build_candidates if candidate.is_file()), None)
+    if ndk_build is not None:
+        report.ok("ndk-build", str(ndk_build))
+    else:
+        report.fail("ndk-build", f"not found under {ndk}")
+
+    rust_bin = ndk / "toolchains" / "rust" / "bin"
+    for name in ("cargo", "rustc"):
+        candidates = [name, f"{name}.exe", rust_bin / name, rust_bin / f"{name}.exe"]
+        found = first_command(*[os.fspath(candidate) for candidate in candidates])
+        if found is None:
+            report.fail(name, f"not found on PATH or under {rust_bin}")
+        else:
+            report.ok(name, found)
+
+
+def check_magiskboot(report: Report) -> None:
+    value = os.environ.get("MAGISKBOOT_PATH")
+    if not value:
+        report.fail("magiskboot", "set MAGISKBOOT_PATH to a host magiskboot binary")
+        return
+    resolved = command_path(value)
+    if resolved is None:
+        report.fail("magiskboot", f"not found: {value}")
+    elif os.name != "nt" and not os.access(resolved, os.X_OK):
+        report.fail("magiskboot", f"not executable: {resolved}")
+    else:
+        report.ok("magiskboot", resolved)
+
+
+def check_boot_image(path: Path) -> str:
+    if not path.is_file():
+        raise RuntimeError("file not found")
+    with path.open("rb") as stream:
+        magic = stream.read(8)
+    if magic == b"ANDROID!":
+        return "AOSP Android boot image"
+    if magic == b"VNDRBOOT":
+        return "vendor_boot image (kernel is normally in boot.img, not vendor_boot.img)"
+    return f"unrecognized first 8 bytes: {magic!r}; magiskboot may still support it"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check prerequisites without changing repositories or files.")
+    parser.add_argument("--boot-image", type=Path, help="optional image to identify")
+    parser.add_argument("--check-native-build", action="store_true", help="also require Magisk's NDK build prerequisites")
+    parser.add_argument("--require-magiskboot", action="store_true", help="require MAGISKBOOT_PATH")
+    args = parser.parse_args()
+
+    report = Report()
+    print(f"Platform: {platform.platform()}")
+
+    git_available = command_path("git") is not None
+    report.check("git", check_command("git"))
+    report.check("uv", check_command("uv"))
+
+    try:
+        magisk = required_env("MAGISK_REPO_DIR")
+    except RuntimeError as error:
+        report.fail("MAGISK_REPO_DIR", str(error))
+        magisk = None
+    try:
+        vmlinux_to_elf = required_env("VMLINUX_TO_ELF_REPO_DIR")
+    except RuntimeError as error:
+        report.fail("VMLINUX_TO_ELF_REPO_DIR", str(error))
+        vmlinux_to_elf = None
+
+    if magisk is not None and git_available:
+        check_repo(
+            magisk,
+            "Magisk repository",
+            configured_url("MAGISK_REPO_URL", MAGISK_URL),
+            submodules=True,
+            report=report,
+        )
+    if vmlinux_to_elf is not None and git_available:
+        check_repo(
+            vmlinux_to_elf,
+            "vmlinux-to-elf repository",
+            configured_url("VMLINUX_TO_ELF_REPO_URL", VMLINUX_TO_ELF_URL),
+            submodules=False,
+            report=report,
+        )
+        check_vmlinux_environment(Path(__file__).resolve().parent, report)
+
+    readelf_override = os.environ.get("READELF_PATH")
+    readelf_name = readelf_override or "readelf"
+    readelf = command_path(readelf_name)
+    if readelf is None and readelf_override is None:
+        readelf = command_path("llvm-readelf")
+    if readelf is None:
+        report.fail("ELF symbol reader", f"{readelf_name} (or llvm-readelf) is not available")
+    else:
+        report.ok("ELF symbol reader", readelf)
+
+    nm_override = os.environ.get("NM_PATH")
+    nm_name = nm_override or "nm"
+    nm = command_path(nm_name)
+    if nm is None and nm_override is None:
+        nm = command_path("llvm-nm")
+    if nm is None:
+        report.warn("nm fallback", f"{nm_name} (or llvm-nm) is not available")
+    else:
+        report.ok("nm fallback", nm)
+
+    if args.check_native_build:
+        check_native_build(report)
+    else:
+        check_host_compiler(report, required=False)
+        report.warn(
+            "native build toolchain",
+            "not required for the standard extractor; use --check-native-build only when building magiskboot",
+        )
+
+    if args.require_magiskboot:
+        check_magiskboot(report)
+    elif os.environ.get("MAGISKBOOT_PATH"):
+        check_magiskboot(report)
+    else:
+        report.warn(
+            "magiskboot",
+            "MAGISKBOOT_PATH is unset; the standard-library AOSP extractor will be used",
+        )
+
+    if args.boot_image:
+        report.check("boot image", lambda: check_boot_image(args.boot_image))
+
+    print()
+    if report.failures:
+        print(f"Preflight: FAIL ({report.failures} required check(s) failed)")
+        return 1
+    print(f"Preflight: PASS ({report.warnings} warning(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"preflight: error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/kallsyms/reconstruct_vmlinux.py
+++ b/tools/kallsyms/reconstruct_vmlinux.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Reconstruct an ELF vmlinux from a kernel payload."""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "lz4",
+#   "zstandard>=0.25.0",
+#   "minilzo>=1.2",
+#   "peewee>=3.17",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import List, Union
+
+from common import ensure_file, expanded_path, python_env, required_env, run
+
+
+MODULE = "vmlinux_to_elf.scripts.vmlinux_to_elf"
+CLI_MODULES = (
+    MODULE,
+    "vmlinux_to_elf.scripts.kallsyms_finder",
+    "vmlinux_to_elf.scripts.vmlinuz_decompressor",
+)
+
+
+def check_upstream(repo: Path) -> None:
+    for module in CLI_MODULES:
+        result = run(
+            [sys.executable, "-m", module, "--help"],
+            env=python_env(repo),
+            capture=True,
+            check=False,
+        )
+        if result.returncode:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise RuntimeError(
+                f"{module} is not runnable: {detail or f'exited with status {result.returncode}'}"
+            )
+
+
+def build_command(kernel: Path, output: Path, args: argparse.Namespace) -> List[Union[str, os.PathLike[str]]]:
+    command: List[Union[str, os.PathLike[str]]] = [sys.executable, "-m", MODULE, kernel, output]
+    for option, value in (
+        ("--e-machine", args.e_machine),
+        ("--bit-size", args.bit_size),
+        ("--file-offset", args.file_offset),
+        ("--base-address", args.base_address),
+        ("--bss-size", args.bss_size),
+    ):
+        if value is not None:
+            command.extend([option, value])
+    if args.use_absolute:
+        command.append("--use-absolute")
+    return command
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Reconstruct vmlinux with vmlinux-to-elf.")
+    parser.add_argument("kernel", type=Path, nargs="?", help="extracted raw or compressed kernel")
+    parser.add_argument("output", type=Path, nargs="?", help="output ELF path, usually named vmlinux")
+    parser.add_argument(
+        "--check-upstream",
+        action="store_true",
+        help="verify the cloned vmlinux-to-elf CLI without processing a kernel",
+    )
+    parser.add_argument("--e-machine", help="override ELF e_machine, for example 183 for AArch64")
+    parser.add_argument("--bit-size", choices=("32", "64"), help="override kernel bitness")
+    parser.add_argument("--file-offset", help="kernel file offset, hexadecimal as accepted by vmlinux-to-elf")
+    parser.add_argument("--base-address", help="kernel base address, hexadecimal as accepted by vmlinux-to-elf")
+    parser.add_argument("--bss-size", help="BSS size passed to vmlinux-to-elf")
+    parser.add_argument("--use-absolute", action="store_true", help="pass --use-absolute")
+    args = parser.parse_args()
+
+    repo = required_env("VMLINUX_TO_ELF_REPO_DIR")
+    if not repo.is_dir():
+        raise RuntimeError(f"VMLINUX_TO_ELF_REPO_DIR is not a directory: {repo}")
+
+    if args.check_upstream:
+        if args.kernel is not None or args.output is not None:
+            parser.error("--check-upstream does not accept kernel or output arguments")
+        check_upstream(repo)
+        print("vmlinux-to-elf CLI checks passed")
+        return 0
+    if args.kernel is None or args.output is None:
+        parser.error("kernel and output are required unless --check-upstream is used")
+
+    kernel = expanded_path(args.kernel)
+    output = expanded_path(args.output)
+    ensure_file(kernel, "kernel input")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    command = build_command(kernel, temporary, args)
+    try:
+        result = run(command, env=python_env(repo), check=False)
+        if result.returncode:
+            raise RuntimeError(f"vmlinux-to-elf exited with status {result.returncode}")
+        # vmlinux-to-elf can report an unsupported architecture through a
+        # zero-status exit; the output check catches that case.
+        ensure_file(temporary, "reconstructed ELF")
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    print(f"Reconstructed ELF: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"reconstruct_vmlinux: error: {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
Add a documented, end-to-end workflow for extracting a boot image, reconstructing a symbolized kernel, and producing the offsets GhostLock needs. The command-line tools now accept explicit symbol inputs, tolerate `readelf` symbol-type output, report SELinux state layout, and avoid committing Python bytecode caches.

#### AI Disclosure
GPT-5.6-Luna and GPT-5.6-Terra were used for development.