### PR TITLE
chore: add local Codex workspace defaults

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+approval_policy = "never"
+approvals_reviewer = "auto_review"
+
+[sandbox_workspace_write]
+network_access = true


### PR DESCRIPTION
These settings configure Codex to run more autonomously within the sandbox. Network access is permitted so wireless ADB can be used to push and invoke ghostlock and pull logs from the device.